### PR TITLE
remove underline on logo

### DIFF
--- a/pantheon_new_relic_header.css
+++ b/pantheon_new_relic_header.css
@@ -19,6 +19,11 @@ a {
     text-decoration: none;
 }
 
+a:hover,
+a:active {
+    border-bottom: 0;
+}
+
 #pantheon-logo{
 	font-size: 1.5em;
     line-height: 1em;


### PR DESCRIPTION
Overwrites some new relic default css that adds a bottom border on hover, over the logo.

![image](https://cloud.githubusercontent.com/assets/19398001/16321153/3569c584-3950-11e6-9ef1-8508c19edae4.png)

@hdahme 
